### PR TITLE
Harden API Contract, Add Unicode Support, and Enforce Coverage Gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,10 @@ on:
     paths:
       - 'tests/**'
       - 'framework/**'
+      - 'mock_server/**'
       - 'requirements.txt'
       - 'docker-compose.yml'
+      - 'pytest.ini'
 
 jobs:
   test:
@@ -67,7 +69,7 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
           DATABASE_URL: postgresql://qauser:qapassword@localhost:5432/qadb
-        run: pytest tests --html=reports/report.html --self-contained-html
+        run: pytest tests
 
       # ---------------------------
       # PERFORMANCE TESTS (JMETER)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+coverage.xml
+htmlcov/
+
+# Pytest-html / local runs
+reports/report.html
+reports/ai_responses.csv

--- a/README.md
+++ b/README.md
@@ -76,11 +76,23 @@ To reproduce specific test failures locally:
     ```bash
     pytest -v --html=reports/debug_report.html
     ```
+    **Python code coverage** runs with every `pytest` via `pytest-cov` in `pytest.ini` (`framework` + `mock_server`, term-missing report, **`--cov-fail-under=85`**). That is separate from **JMeter**, which measures load and latency, not statement coverage.
 3.  **Execute Performance Tests:**
     *(Requires local JMeter 5.6.3 installation)*
     ```bash
     ./jmeter/bin/jmeter -n -t jmeter_test_plan.jmx -l results.jtl -Jjmeter.save.saveservice.output_format=csv
     ```
+
+---
+
+## API Contract (Tested)
+- `POST /chat` accepts JSON payloads with a `prompt` field.
+- `prompt is null` or missing -> `400` with a JSON body that includes a non-empty string `error` (`Prompt is null`). Invalid or unparseable JSON is treated like an empty object, so missing `prompt` yields the same outcome.
+- `prompt` is present but not a JSON string (number, boolean, array, object) -> `400` with `error` containing `Prompt must be a string`.
+- `prompt` as empty/whitespace-only string -> `400` with a JSON body that includes a non-empty string `error`.
+- `len(prompt) > 5000` (Unicode code points, not bytes) -> `413` with a JSON body that includes a non-empty string `error`.
+- Any non-empty string prompt (including unicode, emoji, and symbols) with `len(prompt) <= 5000` -> `200` with a JSON body containing exactly one key: `response` (non-empty string).
+- Error schema is flexible by contract: responses must include `error`, and may include additional keys such as `code`, `details`, or `request_id`.
 
 ---
 

--- a/framework/api_client.py
+++ b/framework/api_client.py
@@ -39,6 +39,15 @@ class AIClient:
                 response.elapsed.total_seconds()
             ])
 
+    @staticmethod
+    def _safe_text(value):
+        """
+        Return a console-safe representation for Windows cp1252 terminals.
+        Preserves readability while avoiding UnicodeEncodeError on emoji.
+        """
+        text = str(value)
+        return text.encode("ascii", "backslashreplace").decode("ascii")
+
     def send_prompt(self, prompt):
         """
         Sends a prompt to the chatbot API and returns the response object.
@@ -56,15 +65,58 @@ class AIClient:
 
         # Print response for debugging (visible in terminal or GitHub Actions logs)
         try:
-            print("PROMPT:", prompt)
-            print("RESPONSE:", response.json())
+            print("PROMPT:", self._safe_text(prompt))
+            print("RESPONSE:", self._safe_text(response.json()))
         except Exception:
-            print("PROMPT:", prompt)
-            print("RESPONSE:", response.text)
+            print("PROMPT:", self._safe_text(prompt))
+            print("RESPONSE:", self._safe_text(response.text))
 
         # Save response to CSV
         self._log_response(prompt, response)
 
+        return response
+
+    def send_chat_payload(self, payload):
+        """
+        POST /chat with an arbitrary JSON object (contract tests: missing key,
+        wrong types, extra fields).
+        """
+        endpoint = self.url if self.url.endswith("/chat") else f"{self.url}/chat"
+        response = requests.post(
+            endpoint,
+            json=payload,
+            timeout=5,
+            verify=False,
+        )
+        try:
+            print("PAYLOAD:", self._safe_text(payload))
+            print("RESPONSE:", self._safe_text(response.json()))
+        except Exception:
+            print("PAYLOAD:", self._safe_text(payload))
+            print("RESPONSE:", self._safe_text(response.text))
+        self._log_response(repr(payload), response)
+        return response
+
+    def send_chat_raw(self, body, content_type="application/json"):
+        """
+        POST /chat with a raw body string (malformed JSON, wrong Content-Type).
+        """
+        endpoint = self.url if self.url.endswith("/chat") else f"{self.url}/chat"
+        headers = {"Content-Type": content_type}
+        response = requests.post(
+            endpoint,
+            data=body,
+            headers=headers,
+            timeout=5,
+            verify=False,
+        )
+        try:
+            print("RAW BODY:", self._safe_text(body[:200] if body else body))
+            print("RESPONSE:", self._safe_text(response.json()))
+        except Exception:
+            print("RAW BODY:", self._safe_text(body[:200] if body else body))
+            print("RESPONSE:", self._safe_text(response.text))
+        self._log_response(body, response)
         return response
 
     def check_health(self):

--- a/mock_server/__init__.py
+++ b/mock_server/__init__.py
@@ -1,0 +1,1 @@
+# Namespace package marker for `import mock_server.chatbot_mock` in tests.

--- a/mock_server/chatbot_mock.py
+++ b/mock_server/chatbot_mock.py
@@ -2,16 +2,37 @@ from flask import Flask, request, jsonify
 
 app = Flask(__name__)
 
+MAX_PROMPT_LENGTH = 5000
+
+
 @app.route("/chat", methods=["POST"])
 def chat():
     data = request.get_json(silent=True) or {}
-    prompt = data.get("prompt", "")
+    prompt = data.get("prompt")
+
+    # Null / missing prompt field
+    if prompt is None:
+        return jsonify({"error": "Prompt is null"}), 400
+
+    # Wrong type (numbers, booleans, objects, arrays, etc.)
+    if not isinstance(prompt, str):
+        return jsonify({"error": "Prompt must be a string"}), 400
+
+    # Empty or whitespace-only
+    if prompt.strip() == "":
+        return jsonify({"error": "Prompt is empty"}), 400
+
+    # Oversized payload (length is Unicode code points, not bytes)
+    if len(prompt) > MAX_PROMPT_LENGTH:
+        return jsonify({"error": "Payload too large"}), 413
+
     return jsonify({"response": f"Mock reply to: {prompt}"})
 
-# ADD THIS
+
 @app.route("/health", methods=["GET"])
 def health():
-    return {"status": "ok"}
+    return jsonify({"status": "ok"})
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,14 @@
 testpaths = tests
 python_files = test_*.py
 python_functions = test_*
-addopts = --html=reports/report.html --self-contained-html
+pythonpath = .
+addopts =
+    --html=reports/report.html
+    --self-contained-html
+    --capture=tee-sys
+    --cov=framework
+    --cov=mock_server
+    --cov-report=term-missing
+    --cov-fail-under=85
+log_cli = true
+log_cli_level = INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-cov
 requests
 pytest-html
 flask

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,38 @@
 import pytest
 import requests_mock
+from pathlib import Path
+
 from framework.api_client import AIClient
+
+MAX_PROMPT_LENGTH = 5000
+
+# HTML report ordering follows execution order — run legacy tests first so their
+# stdout/logs (e.g. from AIClient) appear toward the beginning of the report.
+_TEST_MODULE_ORDER = [
+    "test_api_health.py",
+    "test_chat_workflows.py",
+    "test_edge_cases.py",
+    "test_more_edge_cases.py",
+    "test_chat_contract_flask.py",
+    "test_chat_contract_mocked.py",
+    "test_api_client_resilience.py",
+]
+
+
+def pytest_collection_modifyitems(config, items):
+    rank = {name: idx for idx, name in enumerate(_TEST_MODULE_ORDER)}
+    fallback = len(_TEST_MODULE_ORDER)
+
+    def sort_key(it):
+        mod_name = Path(getattr(it, "path", it.fspath)).name
+        line = (
+            it.location[1]
+            if it.location and it.location[1] is not None
+            else 0
+        )
+        return (rank.get(mod_name, fallback), line, it.nodeid)
+
+    items.sort(key=sort_key)
 
 
 @pytest.fixture
@@ -13,18 +45,28 @@ def mock_ai_service():
     with requests_mock.Mocker() as m:
 
         def dynamic_response(request, context):
-            data = request.json()
+            # Mirror Flask: invalid/missing JSON body -> {} -> prompt None
+            try:
+                data = request.json()
+            except (ValueError, TypeError):
+                data = {}
+            if data is None:
+                data = {}
             prompt = data.get("prompt")
 
             if prompt is None:
                 context.status_code = 400
                 return {"error": "Prompt is null"}
 
-            if isinstance(prompt, str) and prompt.strip() == "":
+            if not isinstance(prompt, str):
+                context.status_code = 400
+                return {"error": "Prompt must be a string"}
+
+            if prompt.strip() == "":
                 context.status_code = 400
                 return {"error": "Prompt is empty"}
 
-            if isinstance(prompt, str) and len(prompt) > 5000:
+            if len(prompt) > MAX_PROMPT_LENGTH:
                 context.status_code = 413
                 return {"error": "Payload too large"}
 
@@ -32,6 +74,6 @@ def mock_ai_service():
             return {"response": f"Mocked response: {prompt}"}
 
         m.post("https://localhost:5000/chat", json=dynamic_response)
-        m.get("https://localhost:5000/health", status_code=200)
+        m.get("https://localhost:5000/health", json={"status": "ok"}, status_code=200)
 
         yield m

--- a/tests/test_api_client_resilience.py
+++ b/tests/test_api_client_resilience.py
@@ -1,0 +1,57 @@
+"""
+AIClient behavior when the transport layer fails or returns non-JSON bodies.
+
+Uses unittest.mock so no real HTTP or requests_mock route is required.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from framework.api_client import AIClient
+
+
+@pytest.fixture
+def bare_client():
+    return AIClient("https://localhost:5000")
+
+
+def test_connect_timeout_propagates(bare_client):
+    with patch(
+        "framework.api_client.requests.post",
+        side_effect=requests.exceptions.ConnectTimeout(),
+    ):
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            bare_client.send_prompt("hello")
+
+
+def test_connection_error_propagates(bare_client):
+    with patch(
+        "framework.api_client.requests.post",
+        side_effect=requests.exceptions.ConnectionError("refused"),
+    ):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            bare_client.send_prompt("hello")
+
+
+def test_read_timeout_propagates(bare_client):
+    with patch(
+        "framework.api_client.requests.post",
+        side_effect=requests.exceptions.ReadTimeout(),
+    ):
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            bare_client.send_prompt("hello")
+
+
+def test_non_json_error_body_still_returns_response(bare_client):
+    fake = MagicMock()
+    fake.status_code = 502
+    fake.text = "<html><body>Bad Gateway</body></html>"
+    fake.elapsed.total_seconds.return_value = 0.05
+    fake.json.side_effect = ValueError("No JSON")
+
+    with patch("framework.api_client.requests.post", return_value=fake):
+        r = bare_client.send_prompt("hello")
+
+    assert r.status_code == 502
+    assert "html" in r.text.lower()

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,9 +1,17 @@
-from framework.api_client import AIClient
+"""
+API health / smoke tests.
 
-client = AIClient()
+Previously used a module-level AIClient() that bypassed the mock fixture.
+Now uses the `client` fixture so tests are fully isolated.
+"""
 
-def test_api_available():
 
+def test_api_available(client):
     response = client.send_prompt("Hello")
-    print("LOGGING RESPONSE TO CSV")
     assert response.status_code == 200
+
+
+def test_health_endpoint(client):
+    """Health check endpoint should return 200."""
+    response = client.check_health()
+    assert response["status"] == "ok"

--- a/tests/test_chat_contract_flask.py
+++ b/tests/test_chat_contract_flask.py
@@ -1,0 +1,138 @@
+"""
+HTTP contract tests against the Flask mock app (same code path as Docker image).
+
+Uses Flask's test client so JSON parsing, methods, and Content-Type behave like production.
+"""
+import json
+import unicodedata
+
+import pytest
+
+from mock_server.chatbot_mock import MAX_PROMPT_LENGTH, app
+
+
+@pytest.fixture
+def flask_client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def _assert_flexible_error(data):
+    assert "error" in data
+    assert isinstance(data["error"], str)
+    assert len(data["error"]) > 0
+
+
+def test_missing_prompt_key_returns_null_error(flask_client):
+    for payload in ({}, {"other": "x"}):
+        resp = flask_client.post("/chat", json=payload)
+        assert resp.status_code == 400
+        data = resp.get_json()
+        _assert_flexible_error(data)
+        assert data["error"] == "Prompt is null"
+
+
+def test_explicit_null_prompt(flask_client):
+    resp = flask_client.post("/chat", json={"prompt": None})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Prompt is null"
+
+
+@pytest.mark.parametrize(
+    "bad_prompt",
+    [123, True, False, [], {}, ["x"], {"a": 1}],
+)
+def test_non_string_prompt_must_be_string(flask_client, bad_prompt):
+    resp = flask_client.post("/chat", json={"prompt": bad_prompt})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    _assert_flexible_error(data)
+    assert data["error"] == "Prompt must be a string"
+
+
+def test_extra_json_keys_still_success(flask_client):
+    resp = flask_client.post(
+        "/chat",
+        json={"prompt": "hi", "meta": {"trace": "abc"}},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert set(data.keys()) == {"response"}
+    assert "hi" in data["response"]
+
+
+def test_malformed_json_body_treated_as_missing_prompt(flask_client):
+    resp = flask_client.post(
+        "/chat",
+        data="{not valid json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Prompt is null"
+
+
+def test_wrong_content_type_plain_text(flask_client):
+    resp = flask_client.post(
+        "/chat",
+        data="just text",
+        content_type="text/plain",
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Prompt is null"
+
+
+def test_prompt_length_boundary_multibyte(flask_client):
+    token = "😀"
+    ok = token * MAX_PROMPT_LENGTH
+    assert len(ok) == MAX_PROMPT_LENGTH
+    resp = flask_client.post("/chat", json={"prompt": ok})
+    assert resp.status_code == 200
+
+    too_long = token * (MAX_PROMPT_LENGTH + 1)
+    resp = flask_client.post("/chat", json={"prompt": too_long})
+    assert resp.status_code == 413
+    _assert_flexible_error(resp.get_json())
+
+
+def test_unicode_normalization_nfd_still_accepted(flask_client):
+    nfd = unicodedata.normalize("NFD", "café")
+    resp = flask_client.post("/chat", json={"prompt": nfd})
+    assert resp.status_code == 200
+
+
+@pytest.mark.parametrize("ws", ["\r", "\f", "\v", "\r\n\v\f"])
+def test_ascii_control_whitespace_only_rejected(flask_client, ws):
+    resp = flask_client.post("/chat", json={"prompt": ws})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Prompt is empty"
+
+
+def test_nbsp_only_stripped_as_whitespace(flask_client):
+    """NBSP (U+00A0) is stripped by str.strip() in CPython; all-NBSP is empty."""
+    prompt = "\u00a0" * 5
+    assert len(prompt.strip()) == 0
+    resp = flask_client.post("/chat", json={"prompt": prompt})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Prompt is empty"
+
+
+def test_post_chat_json_content_type(flask_client):
+    resp = flask_client.post("/chat", json={"prompt": "ok"})
+    assert resp.status_code == 200
+    assert "application/json" in (resp.headers.get("Content-Type") or "").lower()
+
+
+def test_get_chat_not_allowed(flask_client):
+    resp = flask_client.get("/chat")
+    assert resp.status_code == 405
+
+
+def test_put_chat_not_allowed(flask_client):
+    resp = flask_client.put("/chat", json={"prompt": "x"})
+    assert resp.status_code == 405
+
+
+def test_post_health_not_allowed(flask_client):
+    resp = flask_client.post("/health", json={})
+    assert resp.status_code == 405

--- a/tests/test_chat_contract_mocked.py
+++ b/tests/test_chat_contract_mocked.py
@@ -1,0 +1,40 @@
+"""
+Contract tests through AIClient + requests_mock (mirrors Flask rules in conftest).
+"""
+import pytest
+
+from mock_server.chatbot_mock import MAX_PROMPT_LENGTH
+
+
+def test_missing_prompt_key_via_mock(client):
+    for payload in ({}, {"other": 1}):
+        r = client.send_chat_payload(payload)
+        assert r.status_code == 400
+        assert r.json()["error"] == "Prompt is null"
+
+
+@pytest.mark.parametrize(
+    "bad_prompt",
+    [123, True, False, [], {}, ["a"]],
+)
+def test_non_string_prompt_via_mock(client, bad_prompt):
+    r = client.send_chat_payload({"prompt": bad_prompt})
+    assert r.status_code == 400
+    assert r.json()["error"] == "Prompt must be a string"
+
+
+def test_malformed_json_raw_via_mock(client):
+    r = client.send_chat_raw("{not json")
+    assert r.status_code == 400
+    assert r.json()["error"] == "Prompt is null"
+
+
+def test_multibyte_length_boundary_via_mock(client):
+    token = "😀"
+    ok = token * MAX_PROMPT_LENGTH
+    r = client.send_chat_payload({"prompt": ok})
+    assert r.status_code == 200
+
+    r = client.send_chat_payload({"prompt": token * (MAX_PROMPT_LENGTH + 1)})
+    assert r.status_code == 413
+    assert "error" in r.json()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,16 +1,23 @@
-from framework.api_client import AIClient
+"""
+Edge-case tests — all use the `client` fixture from conftest.py so every
+request is intercepted by the `mock_ai_service` fixture.
 
-client = AIClient()
+Previously this file instantiated AIClient() at module level, which bypassed
+the requests_mock entirely and sent real HTTP calls to a server that isn't
+running in CI. That caused the empty-prompt test to receive a 200 instead of
+the expected 400.
+"""
+import pytest
 
-def test_empty_prompt():
 
+def test_empty_prompt(client):
+    """Empty string → mock returns 400 (prompt.strip() == '')."""
     response = client.send_prompt("")
-
     assert response.status_code == 400
+    assert response.json()["error"] == "Prompt is empty"
 
 
-def test_gibberish_prompt():
-
+def test_gibberish_prompt(client):
+    """Non-empty strings are valid inputs → 200."""
     response = client.send_prompt("asdkfjasldkfj")
-
     assert response.status_code == 200

--- a/tests/test_more_edge_cases.py
+++ b/tests/test_more_edge_cases.py
@@ -1,28 +1,135 @@
-import pytest
-from framework.api_client import AIClient
+"""
+Extended edge-case and contract tests.
 
-# Using the client fixture from conftest.py
+Covers:
+- Empty / whitespace-only prompts
+- Oversized payloads
+- Special characters and emoji (unicode)
+- Null / missing prompt field
+- Response schema validation
+"""
+import pytest
+
+from mock_server.chatbot_mock import MAX_PROMPT_LENGTH
+
+
+# ── Boundary: empty & whitespace ────────────────────────────────────────────
+
 def test_empty_prompt(client):
-    """Verify that an empty prompt returns a 400 error."""
+    """Exact empty string → 400 with an error message."""
     response = client.send_prompt("")
     assert response.status_code == 400
+    data = response.json()
+    assert "error" in data
+    assert isinstance(data["error"], str)
+    assert len(data["error"]) > 0
+    assert data["error"] == "Prompt is empty"
 
-def test_very_long_prompt(client):
-    """Verify system handles large inputs (e.g., 5000+ characters)."""
-    long_prompt = "AI " * 2000 
-    response = client.send_prompt(long_prompt)
-    # Depending on your mock, this might be 200 or a 413 (Payload Too Large)
+
+@pytest.mark.parametrize("blank", [
+    " ",          # single space
+    "   ",        # multiple spaces
+    "\t",         # tab
+    "\n",         # newline
+    "  \t\n  ",   # mixed whitespace
+])
+def test_whitespace_only_prompt(client, blank):
+    """
+    Any prompt that is only whitespace trims to an empty string.
+    The mock's `prompt.strip() == ''` guard catches all of these → 400.
+    """
+    response = client.send_prompt(blank)
+    assert response.status_code == 400
+    assert response.json()["error"] == "Prompt is empty"
+
+
+# ── Boundary: length contract ────────────────────────────────────────────────
+
+def test_prompt_at_max_length_is_accepted(client):
+    """Exactly MAX_PROMPT_LENGTH characters should be accepted."""
+    prompt = "A" * MAX_PROMPT_LENGTH
+    response = client.send_prompt(prompt)
+    assert response.status_code == 200
+
+
+def test_prompt_over_max_length_is_rejected(client):
+    """MAX_PROMPT_LENGTH + 1 characters should be rejected with 413."""
+    prompt = "A" * (MAX_PROMPT_LENGTH + 1)
+    response = client.send_prompt(prompt)
     assert response.status_code == 413
+    data = response.json()
+    assert "error" in data
+    assert isinstance(data["error"], str)
+    assert len(data["error"]) > 0
 
-def test_special_characters(client):
-    """Verify handling of emojis and symbols: 🚀🔥!@#$%^&*()"""
+
+# ── Boundary: null / missing field ───────────────────────────────────────────
+
+def test_null_prompt(client):
+    """None serialises to JSON null → 400 (prompt is None guard)."""
+    response = client.send_prompt(None)
+    assert response.status_code == 400
+    assert response.json()["error"] == "Prompt is null"
+
+
+# ── Unicode & special characters ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("prompt", [
+    "こんにちは",                          # Japanese
+    "café naïve résumé",                  # Latin accents
+    "مرحبا",                               # Arabic
+    "👋 Hello 🌍",                        # Emoji
+    "🔥😂💀",                             # Emoji-only (non-empty, non-blank)
+    "SELECT * FROM users; DROP TABLE;",   # SQL injection-like string
+    "<script>alert('xss')</script>",      # HTML injection-like string
+    "\u200b\u200c\u200d",                  # Zero-width characters (non-blank after strip? no — these are not whitespace)
+])
+def test_unicode_and_special_characters(client, prompt):
+    """
+    Contract: any non-empty prompt string (including unicode and symbols)
+    is accepted unless it violates explicit validation rules (null/blank/length).
+    """
+    response = client.send_prompt(prompt)
+    assert response.status_code == 200, f"Unexpected status for prompt: {prompt!r}"
+
+
+def test_special_characters_valid_prompt(client):
+    """Emoji mixed with text is a valid non-empty prompt → 200."""
     response = client.send_prompt("🚀 Test with Emojis and Symbols!@#$")
     assert response.status_code == 200
 
-def test_malformed_json_logic(client):
+
+# ── Response schema validation ───────────────────────────────────────────────
+
+def test_response_schema_valid_prompt(client):
     """
-    Verify the client handles scenarios where the prompt key 
-    might be missing or null (if your send_prompt method allows it).
+    A successful response must contain exactly one key: "response",
+    and its value must be a non-empty string.
+
+    Without this test, a response like {"foo": 123} would make
+    test_api_available pass while silently breaking callers.
     """
-    response = client.send_prompt(None)
+    response = client.send_prompt("Hello")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert set(data.keys()) == {"response"}, (
+        f"Unexpected response shape: {data}"
+    )
+    assert isinstance(data["response"], str)
+    assert len(data["response"]) > 0
+
+
+def test_response_schema_error_prompt(client):
+    """
+    Flexible error schema contract:
+    a 4xx response must include an "error" key containing a non-empty string.
+    Additional keys are allowed.
+    """
+    response = client.send_prompt("")
     assert response.status_code == 400
+
+    data = response.json()
+    assert "error" in data, f"Missing 'error' key in: {data}"
+    assert isinstance(data["error"], str)
+    assert len(data["error"]) > 0


### PR DESCRIPTION
This PR integrates edge cases like empty prompts and unicode, while adding an 85% coverage requirement.
PR Summary
This PR hardens the test contract for POST /chat, improves CI quality gates, and makes test reporting more usable.

Standardized prompt validation behavior across mock server and test fixtures:

Added explicit non-string handling ("Prompt must be a string").
Kept null/missing, whitespace-only, and oversize validations explicit and aligned.
Centralized prompt-size contract with MAX_PROMPT_LENGTH = 5000.
Expanded test coverage with new contract and resilience suites:

Added Flask app contract tests (tests/test_chat_contract_flask.py) for malformed JSON, wrong content type, method constraints, multibyte boundaries, unicode normalization, whitespace variants, and response headers.
Added mocked-client contract tests (tests/test_chat_contract_mocked.py) for payload/type and malformed-body paths.
Added client transport resilience tests (tests/test_api_client_resilience.py) for timeout/connection failures and non-JSON error bodies.
Strengthened existing edge-case tests (tests/test_more_edge_cases.py) with boundary-focused assertions and clearer schema expectations.
Improved test determinism and module behavior:

Ensured edge tests consistently use fixtures/mocking paths rather than accidental live calls.
Added mock_server/__init__.py for stable imports.
Added/updated coverage enforcement:

Added pytest-cov dependency.
Configured pytest.ini to run coverage on framework + mock_server, output missing lines, and enforce --cov-fail-under=85.
Updated CI to rely on pytest config and trigger on pytest.ini changes.
Improved test report readability and ordering:

Added collection-order hook to run legacy/original test modules first so output-rich tests appear earlier in HTML report.
Enabled forced capture/log streaming in pytest (tee-sys, log_cli).
Fixed Windows unicode logging issue exposed by forced capture:

Made AIClient console output unicode-safe to avoid UnicodeEncodeError with emoji/non-ASCII prompts.
Documentation updates:

Added/expanded README API contract section (including flexible error schema policy).
Clarified that Python code coverage (pytest-cov) is distinct from JMeter performance testing.
Validation
Full suite passing locally: 61 passed
Coverage gate passing: ~89% total, above 85% threshold.